### PR TITLE
Use foreach_get()/foreach_set() instead of assignment expressions

### DIFF
--- a/VRRenderer.py
+++ b/VRRenderer.py
@@ -8,7 +8,7 @@ from bpy.types import Operator, Panel
 from math import sin, cos, pi
 from datetime import datetime
 from gpu_extras.batch import batch_for_shader
-
+import time
 
 frag_shaders = {
 # Define the fragment shader for the 180-270 degree equirectangular conversion
@@ -700,7 +700,9 @@ class RenderImage(Operator):
         mode = bpy.context.scene.renderModeEnum
         FOV = bpy.context.scene.renderFOV
         renderer = VRRenderer(bpy.context.scene.render.use_multiview, False, mode, FOV)
+        now = time.time()
         renderer.render_and_save() 
+        print("VRRenderer: {} seconds".format(round(time.time() - now, 2)))
         renderer.clean_up() 
         
         return {'FINISHED'}
@@ -730,7 +732,9 @@ class RenderAnimation(Operator):
            
             if bpy.context.scene.frame_current <= self.frame_end:
                 print("VRRenderer: Rendering frame {}".format(bpy.context.scene.frame_current))
+                now = time.time()
                 self._renderer.render_and_save()
+                print("VRRenderer: {} seconds".format(round(time.time() - now, 2)))
                 self._timer = wm.event_timer_add(0.1, window=context.window)
             else:
                 self.clean(context)

--- a/VRRenderer.py
+++ b/VRRenderer.py
@@ -432,7 +432,7 @@ class VRRenderer:
             bpy.data.images.new(outputName, width, height)
         imageRes = bpy.data.images[outputName]
         imageRes.scale(width, height)
-        imageRes.pixels = buffer
+        imageRes.pixels.foreach_set(buffer)
         return imageRes
 
     
@@ -572,12 +572,14 @@ class VRRenderer:
                 renderedImageR = bpy.data.images.new(imageR, self.side_resolution, self.side_resolution)
             
             # Split the render into two images
+            buff = np.empty((imageLen,), dtype=np.float32)
+            renderedImage.pixels.foreach_get(buff)
             if direction == 'back':
-                renderedImageL.pixels = renderedImage.pixels[int(imageLen/2):]
-                renderedImageR.pixels = renderedImage.pixels[0:int(imageLen/2)]
+                renderedImageL.pixels.foreach_set(buff[imageLen//2:])
+                renderedImageR.pixels.foreach_set(buff[:imageLen//2])
             else:
-                renderedImageR.pixels = renderedImage.pixels[int(imageLen/2):]
-                renderedImageL.pixels = renderedImage.pixels[0:int(imageLen/2)]
+                renderedImageR.pixels.foreach_set(buff[imageLen//2:])
+                renderedImageL.pixels.foreach_set(buff[:imageLen//2])
             renderedImageL.pack()
             renderedImageR.pack()
             bpy.data.images.remove(renderedImage)
@@ -651,12 +653,17 @@ class VRRenderer:
             imageResult = bpy.data.images[image_name]
             if self.stereo_mode == 'SIDEBYSIDE':
                 imageResult.scale(2*imageResult1.size[0], imageResult1.size[1])
-                img2arr = np.reshape(np.array(imageResult2.pixels),(imageResult2.size[1], 4*imageResult2.size[0]))
-                img1arr = np.reshape(np.array(imageResult1.pixels),(imageResult1.size[1], 4*imageResult1.size[0]))
-                imageResult.pixels = list(np.concatenate((img2arr, img1arr),axis=1).flatten())
+                img2arr = np.empty((imageResult2.size[1], 4 * imageResult2.size[0]), dtype=np.float32)
+                imageResult2.pixels.foreach_get(img2arr.ravel())
+                img1arr = np.empty((imageResult1.size[1], 4 * imageResult1.size[0]), dtype=np.float32)
+                imageResult1.pixels.foreach_get(img1arr.ravel())
+                imageResult.pixels.foreach_set(np.concatenate((img2arr, img1arr), axis=1).ravel())
             else:
                 imageResult.scale(imageResult1.size[0], 2*imageResult1.size[1])
-                imageResult.pixels = list(imageResult2.pixels) + list(imageResult1.pixels)
+                buff = np.empty((imageResult1.size[0] * 2 * imageResult1.size[1] * 4,), dtype=np.float32)
+                imageResult2.pixels.foreach_get(buff[:buff.shape[0]//2].ravel())
+                imageResult1.pixels.foreach_get(buff[buff.shape[0]//2:].ravel())
+                imageResult.pixels.foreach_set(buff.ravel())
             bpy.data.images.remove(imageResult1)
             bpy.data.images.remove(imageResult2)
            


### PR DESCRIPTION
This Pull Request will makes the rendering process 2x faster (on my machine and scene settings).

#### Background

Using assignment expressions for Blender's `Image.pixels` is very slow.
It can be demonstrated by running the following benchmark code in Blender's Python Console.
```python
import bpy
import numpy as np
from timeit import timeit

# 2048x2048 image
img = bpy.data.images.new("test2048", width=2048, height=2048)

# set
buff = np.full((2048, 2048, 4), 1, dtype=np.float32)

## slow
timeit("img.pixels=buff.ravel()", globals=globals(), number=10)
## fast
timeit("img.pixels.foreach_set(buff.ravel())", globals=globals(), number=10)

# get

## slow
timeit("buff = np.array(img.pixels)", globals=globals(), number=10)
## fast
timeit(("buff = np.empty((2048, 2048, 4), dtype=np.float32); "
       "img.pixels.foreach_get(buff.ravel())"), globals=globals(), number=10)
```
```
>>> timeit("img.pixels=buff.ravel()", globals=globals(), number=10)
33.87671631295234
>>> timeit("img.pixels.foreach_set(buff.ravel())", globals=globals(), number=10)
0.18426130805164576
>>> timeit("buff = np.array(img.pixels)", globals=globals(), number=10)
27.58730833604932
>>> timeit(("buff = np.empty((2048, 2048, 4), dtype=np.float32); "
...        "img.pixels.foreach_get(buff.ravel())"), globals=globals(), number=10)
0.3206498227082193
```
A lot of the current rendering time in eeVR is the overhead of assignment expressions for `Image.pixels`, and using `foreach_get`/`foreach_set` can improve performance.