### PR TITLE
Enable hot reloading

### DIFF
--- a/VRRenderer.py
+++ b/VRRenderer.py
@@ -262,7 +262,7 @@ class VRRenderer:
         self.no_back_image = (self.FOV <= 270)
         self.no_side_images = (self.FOV <= 90) # TODO - Not implemented yet, probably not needed
         self.is_dome = (mode == 'DOME')
-        self.domeMode = bpy.context.scene.domeModeEnum
+        self.domeMode = bpy.context.scene.eeVR.domeModeEnum
         self.createdFiles = set()
         
         # Select the correct shader
@@ -691,7 +691,7 @@ class VRRendererCancel(Operator):
     bl_label = "Cancel the render"
  
     def execute(self, context):
-        context.scene.cancelVRRenderer = True
+        context.scene.eeVR.cancelVRRenderer = True
         return {'FINISHED'}
 
 
@@ -704,8 +704,8 @@ class RenderImage(Operator):
     def execute(self, context):
         print("VRRenderer: execute")
        
-        mode = bpy.context.scene.renderModeEnum
-        FOV = bpy.context.scene.renderFOV
+        mode = bpy.context.scene.eeVR.renderModeEnum
+        FOV = bpy.context.scene.eeVR.renderFOV
         renderer = VRRenderer(bpy.context.scene.render.use_multiview, False, mode, FOV)
         now = time.time()
         renderer.render_and_save() 
@@ -733,7 +733,7 @@ class RenderAnimation(Operator):
             wm = context.window_manager
             wm.event_timer_remove(self._timer)
            
-            if context.scene.cancelVRRenderer:
+            if context.scene.eeVR.cancelVRRenderer:
                 self.cancel(context)
                 return {'CANCELLED'}
            
@@ -752,10 +752,10 @@ class RenderAnimation(Operator):
     def execute(self, context):
         print("VRRenderer: execute")
  
-        context.scene.cancelVRRenderer = False
+        context.scene.eeVR.cancelVRRenderer = False
        
-        mode = bpy.context.scene.renderModeEnum
-        FOV = bpy.context.scene.renderFOV
+        mode = bpy.context.scene.eeVR.renderModeEnum
+        FOV = bpy.context.scene.eeVR.renderFOV
         # knowing it's animation, creates folder outside vrrender class, pass folder name to it
         start_time = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
         folder_name = "Render Result {}/".format(start_time)
@@ -777,7 +777,7 @@ class RenderAnimation(Operator):
        
     def clean(self, context):
         self._renderer.clean_up()
-        context.scene.cancelVRRenderer = True
+        context.scene.eeVR.cancelVRRenderer = True
        
  
  
@@ -795,12 +795,12 @@ class RenderToolsPanel(Panel):
         # Draw the buttons for each of the rendering operators
         layout = self.layout
         col = layout.column()
-        col.prop(context.scene, 'renderModeEnum')
-        if context.scene.renderModeEnum == 'DOME':
-            col.prop(context.scene, 'domeModeEnum')
-        col.prop(context.scene, 'renderFOV')
+        col.prop(context.scene.eeVR, 'renderModeEnum')
+        if context.scene.eeVR.renderModeEnum == 'DOME':
+            col.prop(context.scene.eeVR, 'domeModeEnum')
+        col.prop(context.scene.eeVR, 'renderFOV')
         col.operator("wl.render_image", text="Render Image")
         col.operator("wl.render_animation", text="Render Animation")
-        if not context.scene.cancelVRRenderer:
+        if not context.scene.eeVR.cancelVRRenderer:
             col.operator("wl.render_cancel", text="Cancel")
             col.label(text="Rendering frame {}".format(bpy.context.scene.frame_current))

--- a/VRRenderer.py
+++ b/VRRenderer.py
@@ -687,7 +687,7 @@ class VRRenderer:
 class VRRendererCancel(Operator):
     """Render out the animation"""
    
-    bl_idname = 'wl.render_cancel'
+    bl_idname = 'eevr.render_cancel'
     bl_label = "Cancel the render"
  
     def execute(self, context):
@@ -698,7 +698,7 @@ class VRRendererCancel(Operator):
 class RenderImage(Operator):
     """Render out the animation"""
    
-    bl_idname = 'wl.render_image'
+    bl_idname = 'eevr.render_image'
     bl_label = "Render a single frame"
     
     def execute(self, context):
@@ -718,7 +718,7 @@ class RenderImage(Operator):
 class RenderAnimation(Operator):
     """Render out the animation"""
    
-    bl_idname = 'wl.render_animation'
+    bl_idname = 'eevr.render_animation'
     bl_label = "Render the animation"
    
     def __del__(self):
@@ -799,8 +799,8 @@ class RenderToolsPanel(Panel):
         if context.scene.eeVR.renderModeEnum == 'DOME':
             col.prop(context.scene.eeVR, 'domeModeEnum')
         col.prop(context.scene.eeVR, 'renderFOV')
-        col.operator("wl.render_image", text="Render Image")
-        col.operator("wl.render_animation", text="Render Animation")
+        col.operator(RenderImage.bl_idname, text="Render Image")
+        col.operator(RenderAnimation.bl_idname, text="Render Animation")
         if not context.scene.eeVR.cancelVRRenderer:
-            col.operator("wl.render_cancel", text="Cancel")
+            col.operator(VRRendererCancel.bl_idname, text="Cancel")
             col.label(text="Rendering frame {}".format(bpy.context.scene.frame_current))

--- a/__init__.py
+++ b/__init__.py
@@ -2,22 +2,20 @@
 
 # pylint: disable=import-error
 
-from datetime import datetime
-from math import sin, cos, pi
-import os
-import bpy
-import gpu
-import bgl
-import mathutils
-import numpy as np
-from bpy.types import Operator, Panel
-from gpu_extras.batch import batch_for_shader
+if "bpy" in locals():
+    import importlib
+    importlib.reload(VRRenderer)
+else:
+    from . import VRRenderer
+
 from .VRRenderer import RenderImage, RenderAnimation, RenderToolsPanel, VRRendererCancel
 
-# Register all classes
-def register():
-    """ Register eeVR to Blender """
-    bpy.types.Scene.renderModeEnum = bpy.props.EnumProperty(
+import bpy
+
+# eeVR's properties
+class Properties(bpy.types.PropertyGroup):
+
+    renderModeEnum : bpy.props.EnumProperty(
         items=[
             ("EQUI", "Equirectangular", "Renders in equirectangular projection"),
             ("DOME", "Full Dome", "Renders in full dome projection"),
@@ -25,7 +23,8 @@ def register():
         default="EQUI",
         name="Mode",
     )
-    bpy.types.Scene.domeModeEnum = bpy.props.EnumProperty(
+
+    domeModeEnum : bpy.props.EnumProperty(
         items=[
             ("0", "Equidistant (VTA)", "Renders in equidistant dome projection"),
             ("1", "Hemispherical (VTH)", "Renders in hemispherical dome projection"),
@@ -35,7 +34,8 @@ def register():
         default="0",
         name="Method",
     )
-    bpy.types.Scene.renderFOV = bpy.props.FloatProperty(
+
+    renderFOV : bpy.props.FloatProperty(
         180.0,
         default=180.0,
         name="FOV",
@@ -43,25 +43,20 @@ def register():
         max=360,
         description="Field of view in degrees",
     )
-    bpy.types.Scene.cancelVRRenderer = bpy.props.BoolProperty(
+
+    cancelVRRenderer : bpy.props.BoolProperty(
         name="Cancel", default=True
     )
-    bpy.utils.register_class(RenderImage)
-    bpy.utils.register_class(RenderAnimation)
-    bpy.utils.register_class(RenderToolsPanel)
-    bpy.utils.register_class(VRRendererCancel)
 
+    @classmethod
+    def register(cls):
+        """ Register eeVR's properties to Blender """
+        bpy.types.Scene.eeVR = bpy.props.PointerProperty(type=cls)
 
-# Unregister all classes
-def unregister():
-    """ Unregister eeVR from Blender """
-    del bpy.types.Scene.domeModeEnum
-    del bpy.types.Scene.renderModeEnum
-    del bpy.types.Scene.renderFOV
-    bpy.utils.unregister_class(RenderImage)
-    bpy.utils.unregister_class(RenderAnimation)
-    bpy.utils.unregister_class(RenderToolsPanel)
-    bpy.utils.unregister_class(VRRendererCancel)
+    @classmethod
+    def unregister(cls):
+        """ Unregister eeVR's properties from Blender """
+        del bpy.types.Scene.eeVR
 
 
 bl_info = {
@@ -78,6 +73,11 @@ bl_info = {
     "category": "Render",
 }
 
-# If the script is not an addon when it is run, register the classes
-if __name__ == "__main__":
-    register()
+# REGISTER
+register, unregister = bpy.utils.register_classes_factory((
+    Properties,
+    RenderToolsPanel,
+    RenderImage,
+    RenderAnimation,
+    VRRendererCancel,
+))


### PR DESCRIPTION
Enable hot reloading with F8 key instead of quit and reopen blender.

In addition, eeVR's own properties were grouped into a PropetyGroup to prevent name conflicts.
