### PR TITLE
Use __package__ name for addon preferences #46

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -589,7 +589,7 @@ class Renderer:
         if self.is_stereo:
             self.scene.render.image_settings.views_format = self.view_format
             self.scene.render.image_settings.stereo_3d_format.display_mode = self.stereo_mode
-        if not context.preferences.addons['eeVR'].preferences.remain_temporaries:
+        if not context.preferences.addons[__package__].preferences.remain_temporaries:
             for filename in self.createdFiles:
                 os.remove(filename)
         self.createdFiles.clear()


### PR DESCRIPTION
Fix #46 .

When downloading the ZIP file from Github, the folder name is `eeVR_master` and will be identified by this name in Blender.
`__package__` will always be the name of the package/addon identified by Blender.
