### PR TITLE
Change support level from TESTING to COMMUNITY

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,7 @@ bl_info = {
     "warning": "This addon is still in early alpha, may break your blend file!",
     "wiki_url": "https://github.com/EternalTrail/eeVR",
     "tracker_url": "https://github.com/EternalTrail/eeVR/issues",
-    "support": "TESTING",
+    "support": "COMMUNITY",
     "category": "Render",
 }
 


### PR DESCRIPTION
In Blender 3.5, `Add-ons > Testing` tab has been removed from the release version of Blender.
So add-ons with support=TESTING cannot be activated.
This pull request changes the support level from TESTING to COMMUNITY.

related: https://projects.blender.org/blender/blender/issues/105213