### PR TITLE
Migrate to new gpu module

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -90,7 +90,7 @@ vec2 to_uv_back(vec3 pt)
     return apply_margin(to_uv(pt.x/pt.z, -pt.y/pt.z));
 }
 
-float atan2(in float y, in float x)
+float atan2(float y, float x)
 {
     return x == 0.0 ? sign(y) * 0.5 * PI : atan(y, x);
 }

--- a/renderer.py
+++ b/renderer.py
@@ -159,6 +159,7 @@ fetch_setup = '''
         angle += (tob + lor * (1 - near_horizon)) * (2 - abs(pt.z/pt.y)) * 0.25 * PI;
         if(angle > VCLIP*0.5) discard;
     }
+    fragColor = vec4(0.0);
 '''
 
 fetch_sides = '''


### PR DESCRIPTION
This PR includes the following two changes
1. Migrate from deprecated bgl module to new gpu module
2. Fix black image problem on macOS mentioned in #48

2 is a bug that the output of fragment shader is computed with uninitialized value. This works fine on Linux (and  Windows), but is the cause of the output image showing all black on macOS. Fixed by https://github.com/EternalTrail/eeVR/commit/45971d6a42c665994d82271a22f7145d406f2496

1, Blender developers plan to drop the bgl module and migrate to new cross-platform gpu module.
https://docs.blender.org/api/current/gpu.html
In Blender 3.5 on macOS, the default backend is Metal instead of OpenGL, bgl module already does not work by default.

NOTE:
The following texture settings may not have been ported correctly. I have not figured out how to do that.
```
bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MIN_FILTER, bgl.GL_LINEAR)
bgl.glTexParameterf(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_MAG_FILTER, bgl.GL_LINEAR)
bgl.glTexParameteri(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_S, bgl.GL_CLAMP_TO_EDGE)
bgl.glTexParameteri(bgl.GL_TEXTURE_2D, bgl.GL_TEXTURE_WRAP_T, bgl.GL_CLAMP_TO_EDGE)
```

