### PR TITLE
add EEVEE NEXT to supported compat engine

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -158,7 +158,7 @@ class RenderPanel(Panel):
     bl_category = "eeVR"
     bl_options = {'DEFAULT_CLOSED'}
 
-    COMPAT_ENGINES = {'BLENDER_RENDER', 'BLENDER_EEVEE', 'BLENDER_WORKBENCH'}
+    COMPAT_ENGINES = {'BLENDER_RENDER', 'BLENDER_EEVEE', 'BLENDER_EEVEE_NEXT', 'BLENDER_WORKBENCH'}
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
In Blender 4.2, they have changed the identifier of EEVEE to `BLENDER_EEVEE_NEXT`. If we add this to the script, then the addon is working with 4.2. Without this change , the panel is not displayed visible in RENDER.

This patch maintain compatibility with old version. IT also add the identifier of new blender 4.2

See here: https://developer.blender.org/docs/release_notes/4.2/python_api/#render-settings
> EEVEE identifier has been changed to BLENDER_EEVEE_NEXT